### PR TITLE
Fix a shellcheck warning in unarchive

### DIFF
--- a/bin/unarchive
+++ b/bin/unarchive
@@ -21,7 +21,7 @@ die() {
 }
 
 atomic_file() {
-  { > "$1" ; } &> /dev/null
+  { true > "$1" ; } &> /dev/null
 }
 
 atomic_directory() {


### PR DESCRIPTION
SC2188: This redirection doesn't have a command. Move to its command (or use 'true' as no-op).