### PR TITLE
unarchive: Make (hopefully) everything happy on BSD

### DIFF
--- a/bin/unarchive
+++ b/bin/unarchive
@@ -11,11 +11,11 @@ cleanup() {
 }
 
 info() {
-  echo -e "\e[1;33m$*\e[m"
+  printf "\e[1;33m%s\e[m\n" "$*"
 }
 
 die() {
-  echo "ERROR: $*" >&2
+  printf "\e[1;31mERROR: %s\e[m\n" "$*" >&2
   cleanup
   exit 1
 }
@@ -26,6 +26,15 @@ atomic_file() {
 
 atomic_directory() {
   mkdir -- "$1" 2>/dev/null
+}
+
+replace() {
+  # mv -T is not supported on BSD :(
+  local temp_dir
+  temp_dir=$(mktemp -d tmp.unarchive.XXXXXXXXXX)
+  temp_files+=(${temp_dir})
+  mv -- "$1" "$temp_dir/$2"
+  mv -- "$temp_dir/$2" .
 }
 
 find_unique_name() {
@@ -150,11 +159,11 @@ unarchive() {
     local file_type
     file_type=$([[ -f "${file}" ]] && echo "file" || echo "directory")
     target="$(find_unique_name "$(basename "${file}")" "${file_type}")"
-    mv -T -- "${file}" "${target}"
+    replace "${file}" "${target}"
     info "${archive_orig_path}: Single ${file_type}, moved to ${target}"
   else
     target="$(find_unique_name "${archive_basename}" "directory")"
-    mv -T -- "${temp_dir}" "${target}"
+    replace "${temp_dir}" "${target}"
     info "${archive_orig_path}: Extracted to ${target}"
   fi
 }


### PR DESCRIPTION
Fixed `mv -T` and `echo -e`, which are not supported on BSD.